### PR TITLE
Generalise concurrency groups

### DIFF
--- a/workflows/codeql-analysis.yml
+++ b/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       security-events: write
     concurrency:
-      group: ${{ github.ref }}-codeql
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     strategy:
       fail-fast: false

--- a/workflows/docker-multiarch.yml
+++ b/workflows/docker-multiarch.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     # Cancel earlier job if there is a new one for the same branch/release
     concurrency:
-      group: ${{ github.ref }}-docker-build
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     # Define the images/tags to build; will run in parallell
     strategy:
@@ -38,7 +38,7 @@ jobs:
       packages: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@@v3
       # prepare qemu and buildx to enable multi-architecture builds
       - name: Run setup-qemu-action
         uses: docker/setup-qemu-action@v2

--- a/workflows/docker-security-reject.yml
+++ b/workflows/docker-security-reject.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     # Cancel earlier job if there is a new one for the same branch/release
     concurrency:
-      group: ${{ github.ref }}-docker-build
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     # Define the images/tags to build; will run in parallell
     strategy:

--- a/workflows/docker-security-warning.yml
+++ b/workflows/docker-security-warning.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     # Cancel earlier job if there is a new one for the same branch/release
     concurrency:
-      group: ${{ github.ref }}-docker-build
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     # Define the images/tags to build; will run in parallell
     strategy:

--- a/workflows/docker.yml
+++ b/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     # Cancel earlier job if there is a new one for the same branch/release
     concurrency:
-      group: ${{ github.ref }}-docker-build
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     # Define the images/tags to build; will run in parallell
     strategy:

--- a/workflows/fossa.yml
+++ b/workflows/fossa.yml
@@ -12,7 +12,7 @@ jobs:
   fossa-scan:
     if: github.repository == 'scilifelabdatacentre/repository'
     concurrency:
-      group: ${{ github.ref }}-fossa
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     permissions:
       contents: read

--- a/workflows/python-black.yml
+++ b/workflows/python-black.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 jobs:
   BlackFormatting:
     concurrency:
-      group: ${{ github.ref }}-black
+      group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
       cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Avoid hard-coding the concurrency group.

Suggested string from the Github actions [documentation](https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix):
```
'${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
```