### PR TITLE
Use Alpine instead of the klakegg as base for Hugo builds.

### DIFF
--- a/dockerfiles/Dockerfile.hugo
+++ b/dockerfiles/Dockerfile.hugo
@@ -1,11 +1,16 @@
 # Perform a hugo build and copy the generated files into an nginx image
+# This image uses the version of Hugo available in Alpine Linux, often corresponding to the latest version
 
 # Check for recent versions/tags at https://hub.docker.com/r/klakegg/hugo/tags
-FROM klakegg/hugo:0.106.0-ubuntu-onbuild AS build
-# On run, the image automatically copies the context folder to /src and performs a hugo build to /target
+FROM alpine AS build
+RUN apk update && apk add hugo
+COPY . /src
+WORKDIR /src
+RUN hugo
 
 FROM nginxinc/nginx-unprivileged:alpine
-COPY --from=build /target /usr/share/nginx/html
+COPY --from=build /src/public /usr/share/nginx/html
 RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf
 
+USER 10200
 EXPOSE 8080


### PR DESCRIPTION
Replace klakegg with a build based on Alpine, as klakegg hasn't been updated for ~6 months